### PR TITLE
add proxy env variables to all Dockerfiles

### DIFF
--- a/dockerizeit/master/Dockerfile
+++ b/dockerizeit/master/Dockerfile
@@ -1,9 +1,12 @@
 FROM jenkins:1.642.4
 
 # Add proxy env
-ENV HTTP_PROXY=$http_proxy
-ENV HTTPS_PROXY=$https_proxy
-ENV NO_PROXY=$no_proxy
+ENV HTTP_PROXY=$HTTP_PROXY
+ENV HTTPS_PROXY=$HTTPS_PROXY
+ENV NO_PROXY=$NO_PROXY
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
 
 # Install plugins
 COPY plugins.txt /usr/share/jenkins/plugins.txt

--- a/dockerizeit/master/Dockerfile
+++ b/dockerizeit/master/Dockerfile
@@ -1,5 +1,10 @@
 FROM jenkins:1.642.4
 
+# Add proxy env
+ENV HTTP_PROXY=$http_proxy
+ENV HTTPS_PROXY=$https_proxy
+ENV NO_PROXY=$no_proxy
+
 # Install plugins
 COPY plugins.txt /usr/share/jenkins/plugins.txt
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/plugins.txt

--- a/dockerizeit/munchausen/Dockerfile
+++ b/dockerizeit/munchausen/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:jessie
 
+# Add proxy env
+ENV HTTP_PROXY=$http_proxy
+ENV HTTPS_PROXY=$https_proxy
+ENV NO_PROXY=$no_proxy
+
 # install docker client and pip
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && echo "deb http://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list && apt-get update && apt-get install -y docker-engine python-pip
 

--- a/dockerizeit/munchausen/Dockerfile
+++ b/dockerizeit/munchausen/Dockerfile
@@ -1,9 +1,12 @@
 FROM debian:jessie
 
 # Add proxy env
-ENV HTTP_PROXY=$http_proxy
-ENV HTTPS_PROXY=$https_proxy
-ENV NO_PROXY=$no_proxy
+ENV HTTP_PROXY=$HTTP_PROXY
+ENV HTTPS_PROXY=$HTTPS_PROXY
+ENV NO_PROXY=$NO_PROXY
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
 
 # install docker client and pip
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && echo "deb http://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list && apt-get update && apt-get install -y docker-engine python-pip

--- a/dockerizeit/slave/Dockerfile
+++ b/dockerizeit/slave/Dockerfile
@@ -4,9 +4,12 @@ ENV JENKINS_SWARM_VERSION 2.0
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # Add proxy env
-ENV HTTP_PROXY=$http_proxy
-ENV HTTPS_PROXY=$https_proxy
-ENV NO_PROXY=$no_proxy
+ENV HTTP_PROXY=$HTTP_PROXY
+ENV HTTPS_PROXY=$HTTPS_PROXY
+ENV NO_PROXY=$NO_PROXY
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
 
 # install netstat to allow connection health check with + other tools required by the jobs
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && echo "deb http://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list

--- a/dockerizeit/slave/Dockerfile
+++ b/dockerizeit/slave/Dockerfile
@@ -3,6 +3,11 @@ FROM java:8-jdk
 ENV JENKINS_SWARM_VERSION 2.0
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
+# Add proxy env
+ENV HTTP_PROXY=$http_proxy
+ENV HTTPS_PROXY=$https_proxy
+ENV NO_PROXY=$no_proxy
+
 # install netstat to allow connection health check with + other tools required by the jobs
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && echo "deb http://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y maven git net-tools docker-engine


### PR DESCRIPTION
Add env, variables. While I dont have proxy, they are setting by empty fields. The env are available in docker containers. I wanted to do it by one shell config file, but it seems tricky - still need to be investigated. About proxy variable. Should I set in low case and in high case in the same time, is it any difference ?