### PR TITLE
Decouple host JAVA_OPTS from container JAVA_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git clone https://github.com/Praqma/JenkinsAsCodeReference.git
 export http_proxy=<empty or proxy address>
 export https_proxy=<empty or proxy address>
 export no_proxy=<empty or proxy address>
-export JAVA_OPTS=<empty or -Dhttps.proxyHost=<proxy address> -Dhttps.proxyPort=<proxy port> -Dhttp.nonProxyHosts=localhost,127.0.0.1,*.whatever.com -Dhttp.proxyHost=<proxy address> -Dhttp.proxyPort=<proxy port>
+export JAVA_PROXY=<empty or -Dhttps.proxyHost=<proxy address> -Dhttps.proxyPort=<proxy port> -Dhttp.nonProxyHosts=localhost,127.0.0.1,*.whatever.com -Dhttp.proxyHost=<proxy address> -Dhttp.proxyPort=<proxy port>
 ```
 
 or
@@ -41,7 +41,7 @@ cat > ~/.bashrc <<- EOM
 export http_proxy=<empty or proxy address>
 export https_proxy=<empty or proxy address>
 export no_proxy=<empty or proxy address>
-export JAVA_OPTS=<empty or -Dhttps.proxyHost=<proxy address> -Dhttps.proxyPort=<proxy port> -Dhttp.nonProxyHosts=localhost,127.0.0.1,*.whatever.com -Dhttp.proxyHost=<proxy address> -Dhttp.proxyPort=<proxy port>
+export JAVA_PROXY=<empty or -Dhttps.proxyHost=<proxy address> -Dhttps.proxyPort=<proxy port> -Dhttp.nonProxyHosts=localhost,127.0.0.1,*.whatever.com -Dhttp.proxyHost=<proxy address> -Dhttp.proxyPort=<proxy port>
 EOM
 source ~/.bashrc
 ```

--- a/dockerizeit/docker-compose.yml
+++ b/dockerizeit/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-        - JAVA_OPTS
+        - JAVA_PROXY
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/dockerizeit/master/Dockerfile
+++ b/dockerizeit/master/Dockerfile
@@ -6,8 +6,9 @@ FROM jenkins:2.46.3-alpine
 ENV http_proxy ${http_proxy:-}
 ENV https_proxy ${https_proxy:-}
 ENV no_proxy ${no_proxy:-}
-ARG JAVA_OPTS
-ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false ${JAVA_OPTS:-}"
+ARG JAVA_PROXY
+ENV JAVA_PROXY ${JAVA_PROXY:-}
+ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false ${JAVA_PROXY:-}"
 
 # Define build argument and env variable master_image_version
 # Use to pass info about Jenkins version so it can be represented

--- a/dockerizeit/master/README.md
+++ b/dockerizeit/master/README.md
@@ -308,7 +308,7 @@ gerrit {
 ### Proxy
 
 Configured by the [proxy.groovy](proxy.groovy)
-The script will read http_proxy, https_proxy, no_proxy, JAVA_OPTS environment variables (set during the container build. See [Dockerfile](Dockerfile) for more details) and define then as Jenkins global variables.
+The script will read http_proxy, https_proxy, no_proxy, JAVA_PROXY environment variables (set during the container build. See [Dockerfile](Dockerfile) for more details) and define then as Jenkins global variables.
 
 ### Security configuration
 

--- a/dockerizeit/master/proxy.groovy
+++ b/dockerizeit/master/proxy.groovy
@@ -9,7 +9,7 @@ def helpers = shell.parse(new File("/var/jenkins_home/init.groovy.d/helpers.groo
 println "--> Setting up proxy"
 
 def gradle_opts = ""
-def proxy_vars = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'JAVA_OPTS']
+def proxy_vars = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'JAVA_PROXY']
 for (e in System.getenv()) {
   def key = e.key.toUpperCase()
   if ( ! proxy_vars.contains(key) ) {

--- a/jobdsl-gradle/src/jobs/resources/pipelines/jenkinsdeploy.groovy
+++ b/jobdsl-gradle/src/jobs/resources/pipelines/jenkinsdeploy.groovy
@@ -15,7 +15,7 @@ node(env.utility_slave) {
 
    stage('Build master Docker image') {
        // docker pipeline plugin build command does not implement to take arguments yet
-       sh 'cd dockerizeit/master && docker build --build-arg master_image_version=${master_image_name}:$(git describe --tags) --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --build-arg JAVA_OPTS -t ${master_image_name}:$(git describe --tags) .'
+       sh 'cd dockerizeit/master && docker build --build-arg master_image_version=${master_image_name}:$(git describe --tags) --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --build-arg JAVA_PROXY -t ${master_image_name}:$(git describe --tags) .'
    }
    
     // This have to be outside of stages to be available for other stages


### PR DESCRIPTION
Adding JAVA_PROXY variable to provide to docker image build, so that
when container is host for new image build, the JAVA_PROXY variable
will be added to JAVA_OPTS instead of host's JAVA_OPTS, keeping
control of the JAVA_OPTS in the Dockerfile

Solution to #204 