### PR TITLE
Slave container gets JAVA_PROXY in environment

### DIFF
--- a/dockerizeit/docker-compose.yml
+++ b/dockerizeit/docker-compose.yml
@@ -31,6 +31,7 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
+        - JAVA_PROXY
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/dockerizeit/master/proxy.groovy
+++ b/dockerizeit/master/proxy.groovy
@@ -9,7 +9,7 @@ def helpers = shell.parse(new File("/var/jenkins_home/init.groovy.d/helpers.groo
 println "--> Setting up proxy"
 
 def gradle_opts = ""
-def proxy_vars = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'JAVA_PROXY']
+def proxy_vars = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'JAVA_OPTS']
 for (e in System.getenv()) {
   def key = e.key.toUpperCase()
   if ( ! proxy_vars.contains(key) ) {

--- a/dockerizeit/slave/Dockerfile
+++ b/dockerizeit/slave/Dockerfile
@@ -9,6 +9,8 @@ ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV http_proxy ${http_proxy:-}
 ENV https_proxy ${https_proxy:-}
 ENV no_proxy ${no_proxy:-}
+ARG JAVA_PROXY
+ENV JAVA_PROXY ${JAVA_PROXY}
 
 # install docker
 

--- a/jobdsl-gradle/src/jobs/resources/pipelines/jenkinsdeploy.groovy
+++ b/jobdsl-gradle/src/jobs/resources/pipelines/jenkinsdeploy.groovy
@@ -43,7 +43,7 @@ node(env.utility_slave) {
     }
 
     stage('Build slave Docker image') {
-       sh 'cd dockerizeit/slave && docker build --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy -t ${slave_image_name}:$(git describe --tags) .'
+       sh 'cd dockerizeit/slave && docker build --build-arg JAVA_PROXY --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy -t ${slave_image_name}:$(git describe --tags) .'
     }
 
     // This have to be outside of stages to be available for other stages


### PR DESCRIPTION
For the decoupling of JAVA_OPT and JAVA_PROXY to work with the
jenkins-as-a-code pipeline job to rebuild the docker images, the
slave need to have JAVA_PROXY environment variable available