### PR TITLE
Fix incorrect use of reserved symbol

### DIFF
--- a/dockerizeit/master/slaves.groovy
+++ b/dockerizeit/master/slaves.groovy
@@ -49,7 +49,7 @@ properties.slaves.each {
 
   // Add env variables
   def entryList = []
-  for (var in it.value.env) {
+  it.value.env.each { name, var ->
     entryList.add(new EnvironmentVariablesNodeProperty.Entry(var.key, var.value))
   }
   def evnp = new EnvironmentVariablesNodeProperty(entryList)


### PR DESCRIPTION
Iteration over map results in reserved fields key and value
for the iteration object, but in this case the actual
map objects are named key and value, leading to failed
config.