### PR TITLE
Spelling and formatting corrections to master README

### DIFF
--- a/dockerizeit/master/README.md
+++ b/dockerizeit/master/README.md
@@ -312,14 +312,14 @@ The script will read http_proxy, https_proxy, no_proxy, JAVA_PROXY environment v
 
 ### Security configuration
 
-Security configuration stored in the separate file - [security.properties](security.properies)
+Security configuration stored in the separate file - [security.properties](security.properties)
 
 #### Script security for JobDSL
 
-JobDSL plugin supports script secutiry starting from 1.60. You can disable sandbox mode by using config below
+JobDSL plugin supports script security starting from 1.60. You can disable sandbox mode by using config below
 
 ```
-scriptSecutiry {
+scriptSecurity {
   jobDSL = false
 }
 ```
@@ -328,6 +328,7 @@ scriptSecutiry {
 
 LDAP configuration example. Fields name match [LDAPSecurityRealm](https://github.com/jenkinsci/ldap-plugin/blob/0da2fef8feb9e480e303a7dbd03241f880c82235/src/main/java/hudson/security/LDAPSecurityRealm.java) constructor.
 
+```
 ldap {
   enabled = true
   server = "ldap://1.2.3.4"
@@ -339,6 +340,7 @@ ldap {
   managerPassword = "password"
   inhibitInferRootDN = false
 }
+```
 
 #### AD
 

--- a/jobdsl-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/jobdsl-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 20 20:06:24 CET 2015
+#Tue Mar 27 11:28:23 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-bin.zip

--- a/jobdsl-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/jobdsl-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 27 11:28:23 EDT 2018
+#Tue Mar 27 11:35:51 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip


### PR DESCRIPTION
Just a few tweaks to the README file.  One code block in particular (LDAP config) was missing the surrounding triple-backtick.