### PR TITLE
Use Java syntax in Java property example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git clone https://github.com/Praqma/JenkinsAsCodeReference.git
 export http_proxy=<empty or proxy address>
 export https_proxy=<empty or proxy address>
 export no_proxy=<empty or proxy address>
-export JAVA_PROXY=<empty or -Dhttps.proxyHost=<proxy address> -Dhttps.proxyPort=<proxy port> -Dhttp.nonProxyHosts=localhost,127.0.0.1,*.whatever.com -Dhttp.proxyHost=<proxy address> -Dhttp.proxyPort=<proxy port>
+export JAVA_PROXY=<empty or -Dhttps.proxyHost=<proxy address> -Dhttps.proxyPort=<proxy port> -Dhttp.nonProxyHosts=\"localhost,127.0.0.1|*.whatever.com\" -Dhttp.proxyHost=<proxy address> -Dhttp.proxyPort=<proxy port>
 ```
 
 or
@@ -41,7 +41,7 @@ cat > ~/.bashrc <<- EOM
 export http_proxy=<empty or proxy address>
 export https_proxy=<empty or proxy address>
 export no_proxy=<empty or proxy address>
-export JAVA_PROXY=<empty or -Dhttps.proxyHost=<proxy address> -Dhttps.proxyPort=<proxy port> -Dhttp.nonProxyHosts=localhost,127.0.0.1,*.whatever.com -Dhttp.proxyHost=<proxy address> -Dhttp.proxyPort=<proxy port>
+export JAVA_PROXY=<empty or -Dhttps.proxyHost=<proxy address> -Dhttps.proxyPort=<proxy port> -Dhttp.nonProxyHosts=\"localhost,127.0.0.1|*.whatever.com\" -Dhttp.proxyHost=<proxy address> -Dhttp.proxyPort=<proxy port>
 EOM
 source ~/.bashrc
 ```


### PR DESCRIPTION
The nonProxyHosts property example uses Linux syntax
which may lead to connection problems. Use instead
correct Java syntax for the property.